### PR TITLE
Added possibility to disable escaping

### DIFF
--- a/ProcessBuilder.php
+++ b/ProcessBuilder.php
@@ -30,6 +30,7 @@ class ProcessBuilder
     private $inheritEnv = true;
     private $prefix = array();
     private $outputDisabled = false;
+    private $escape = true;
 
     /**
      * Constructor
@@ -250,6 +251,30 @@ class ProcessBuilder
 
         return $this;
     }
+    
+    /**
+     * Disables auto escaping of arguments.
+     * 
+     * @return $this
+     */
+    public function disableEscaping()
+    {
+        $this->escape = false;
+        
+        return $this;
+    }
+    
+    /**
+     * Enables auto escaping of arguments.
+     * 
+     * @return $this
+     */
+    public function disableEscaping()
+    {
+        $this->escape = true;
+        
+        return $this;
+    }
 
     /**
      * Creates a Process instance and returns it.
@@ -267,7 +292,11 @@ class ProcessBuilder
         $options = $this->options;
 
         $arguments = array_merge($this->prefix, $this->arguments);
-        $script = implode(' ', array_map(array(__NAMESPACE__.'\\ProcessUtils', 'escapeArgument'), $arguments));
+        if ($this->escape) {
+            $arguments = array_map(array(__NAMESPACE__.'\\ProcessUtils', 'escapeArgument'), $arguments)
+        }
+        
+        $script = implode(' ', $arguments);
 
         if ($this->inheritEnv) {
             // include $_ENV for BC purposes


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | todo |

I need to use an environment variable in my process arguments, but there is no way to be able to do that now, since everything is escaped with single quotes. This adds a feature to disable this.

Refs bldr-io/bldr#99
