### PR TITLE
Update Process.php

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -275,7 +275,7 @@ class Process
         $commandline = $this->commandline;
 
         if ('\\' === DIRECTORY_SEPARATOR && $this->enhanceWindowsCompatibility) {
-            $commandline = 'cmd /V:ON /E:ON /C "('.$commandline.')';
+            $commandline = 'cmd /V:ON /E:ON /D /C "('.$commandline.')';
             foreach ($this->processPipes->getFiles() as $offset => $filename) {
                 $commandline .= ' '.$offset.'>'.ProcessUtils::escapeArgument($filename);
             }


### PR DESCRIPTION
Stop any registry based autoexec commands from executing when shelling.

Running Windows CMD as Administrator puts you in C:\windows\system32.

If you have a registry entry of ...
```
Windows Registry Editor Version 5.00

[HKEY_CURRENT_USER\Software\Microsoft\Command Processor]
"AutoRun"="@CD C:\\"
```

Causes all sorts of issues without the ```/D``` option.

From ```CMD /?```

```
/D      Disable execution of AutoRun commands from registry

If /D was NOT specified on the command line, then when CMD.EXE starts, it
looks for the following REG_SZ/REG_EXPAND_SZ registry variables, and if
either or both are present, they are executed first.

    HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor\AutoRun

        and/or

    HKEY_CURRENT_USER\Software\Microsoft\Command Processor\AutoRun

```