### PR TITLE
Fix throw "Unable to kill the process" for quickly ending async-proce…

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -775,7 +775,7 @@ class Process
         if ($this->isRunning()) {
             if ('\\' === DIRECTORY_SEPARATOR && !$this->isSigchildEnabled()) {
                 exec(sprintf('taskkill /F /T /PID %d 2>&1', $this->getPid()), $output, $exitCode);
-                if ($exitCode > 0) {
+                if ($exitCode > 0 && $this->isRunning()) {
                     throw new RuntimeException('Unable to kill the process');
                 }
             }


### PR DESCRIPTION
Hello!

My system is: Windows 10 x64, PHP 5.6:

```
>php --version
PHP 5.6.12 (cli) (built: Aug  6 2015 12:06:20)
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    with the ionCube PHP Loader v5.0.14, Copyright (c) 2002-2015, by ionCube Ltd
```

In `composer.json` I have:

``` json
{
  "name": "itcrab/proccess-test",
  "description": "process-test",
  "minimum-stability": "stable",
  "license": "MIT",
  "authors": [
    {
      "name": "Arcady Usov",
      "email": "itcrab@ya.ru"
    }
  ],
  "require": {
    "symfony/process": "v2.7.5"
  }
}
```

I found the problem in my use case. It's simple to play:
1 - I have small script (code for example):

``` php
<?php

use Symfony\Component\Process\Process;

require_once __DIR__.'/vendor/autoload.php';

$process = new Process('dir');
$process->start();
$process = new Process('dir');
$process->start();
$process = new Process('dir');
$process->start();
$process = new Process('dir');
$process->start();
$process = new Process('dir');
$process->start();
```

2 - when I exec this script got:

```
D:\Projects\Contribute\proccess-test>php index.php

Fatal error: Uncaught exception 'Symfony\Component\Process\Exception\RuntimeExce
ption' with message 'Unable to kill the process' in D:\Projects\Contribute\procc
ess-test\vendor\symfony\process\Process.php:801
Stack trace:
#0 D:\Projects\Contribute\proccess-test\vendor\symfony\process\Process.php(177):
 Symfony\Component\Process\Process->stop()
#1 [internal function]: Symfony\Component\Process\Process->__destruct()
#2 {main}
  thrown in D:\Projects\Contribute\proccess-test\vendor\symfony\process\Process.
php on line 801
```

This PR fix this situation. If you have any questions - please give me know.
