### PR TITLE
Unset callback after stop

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -813,6 +813,8 @@ class Process
             $this->close();
         }
 
+        $this->callback = null;
+
         return $this->exitcode;
     }
 


### PR DESCRIPTION
As of yet, a `Process` instance can't free memory.
The built-in callback has a self-reference to the intance not cleared after instance destruction.
I've tried to change both `buildCallback` and https://github.com/symfony/process/blob/v2.7.6/Process.php#L1373 usage to avoid self-referencing, but it can't be done without breaking BC, and the memory issue is still there.

A simple test script (that obiously can't be embedded in unit-tests)
```php
$echo = function($inc){
    echo (memory_get_usage(true) / 1000000) . ' MB ' . $inc . PHP_EOL;
};
for ($inc = 0; $inc < 10000; $inc++) {
    $process = new Symfony\Component\Process\Process('echo 1');
    $process->mustRun();
    $process->stop();
    unset($process);
    
    $echo($inc);
}
```
Before:
```
1.572864 MB 0
5.505024 MB 9999
```
After:
```
1.572864 MB 0
1.572864 MB 9999
```
Ok, in this simple scenario 4 MB of RAM is nothing, but in our business app full of IOC where `unset`-ting is hard, our RAM explodes.

After `stop()`, the callback is no longer necessary.