### PR TITLE
[Process] don't populate internal buffer if user closure is supplied

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -1211,14 +1211,14 @@ class Process
     {
         $out = self::OUT;
         $callback = function ($type, $data) use ($callback, $out) {
-            if ($out == $type) {
-                $this->addOutput($data);
-            } else {
-                $this->addErrorOutput($data);
-            }
-
             if (null !== $callback) {
                 call_user_func($callback, $type, $data);
+            } else {
+                if ($out == $type) {
+                    $this->addOutput($data);
+                } else {
+                    $this->addErrorOutput($data);
+                }
             }
         };
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ print $process->getOutput();
 
 And if you want to be able to get some feedback in real-time, just pass an
 anonymous function to the ``run()`` method and you will get the output buffer
-as it becomes available:
+as it becomes available instead:
 
 ```php
 use Symfony\Component\Process\Process;


### PR DESCRIPTION
This fixes [Issue 17390](https://github.com/symfony/symfony/issues/17390)