### PR TITLE
Fix is_executable warning exception

### DIFF
--- a/PhpExecutableFinder.php
+++ b/PhpExecutableFinder.php
@@ -65,7 +65,7 @@ class PhpExecutableFinder
             }
         }
 
-        if (is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
+        if (@is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
             return $php;
         }
 


### PR DESCRIPTION
The @ gets rid of the warning when this command fails.

`is_executable(): open_basedir restriction in effect`

![e_warning](https://user-images.githubusercontent.com/14247909/37215844-574fb9c8-23ce-11e8-8b19-26169cddeac7.png)
