### PR TITLE
Suppress warnings when open_basedir is non-empty

### DIFF
--- a/PhpExecutableFinder.php
+++ b/PhpExecutableFinder.php
@@ -36,7 +36,7 @@ class PhpExecutableFinder
     public function find($includeArgs = true)
     {
         if ($php = getenv('PHP_BINARY')) {
-            if (!is_executable($php)) {
+            if (@!is_executable($php)) {
                 return false;
             }
 
@@ -52,7 +52,7 @@ class PhpExecutableFinder
         }
 
         if ($php = getenv('PHP_PATH')) {
-            if (!is_executable($php)) {
+            if (@!is_executable($php)) {
                 return false;
             }
 
@@ -60,12 +60,12 @@ class PhpExecutableFinder
         }
 
         if ($php = getenv('PHP_PEAR_PHP_BIN')) {
-            if (is_executable($php)) {
+            if (@is_executable($php)) {
                 return $php;
             }
         }
 
-        if (is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
+        if (@is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
             return $php;
         }
 


### PR DESCRIPTION
If PHP is configured with a non-empty `open_basedir` value that does not allow access to the target location, these calls to `is_executable()` throw warnings. While Symfony may raise exceptions for warnings in production environments, other frameworks (such as Laravel) do, in which case any of these checks causes a show-stopping 500 error.