### PR TITLE
Suppress warnings when open_basedir is non-empty

### DIFF
--- a/PhpExecutableFinder.php
+++ b/PhpExecutableFinder.php
@@ -49,7 +49,7 @@ class PhpExecutableFinder
         }
 
         if ($php = getenv('PHP_PATH')) {
-            if (!is_executable($php)) {
+            if (@!is_executable($php)) {
                 return false;
             }
 
@@ -57,12 +57,12 @@ class PhpExecutableFinder
         }
 
         if ($php = getenv('PHP_PEAR_PHP_BIN')) {
-            if (is_executable($php)) {
+            if (@is_executable($php)) {
                 return $php;
             }
         }
 
-        if (is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
+        if (@is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
             return $php;
         }
 


### PR DESCRIPTION
While 709e15e7a37cb7ed6199548dc70dc33168e6cb2d did not "cause" this problem, it made it more apparent (because the other `is_executable()` calls are wrapped in conditional logic that makes them less likely to be executed).

If PHP is configured with a non-empty open_basedir value that does not permit access to the target location, these calls to `is_executable()` throw warnings.

While Symfony may not raise exceptions for warnings in production environments, other frameworks (such as Laravel) do, in which case any of these checks causes a show-stopping 500 error.

We fixed a similar issue in the `ExecutableFinder` class via https://github.com/symfony/symfony/pull/16182 .