### PR TITLE
Consider "executable" suffixes first on Windows

### DIFF
--- a/ExecutableFinder.php
+++ b/ExecutableFinder.php
@@ -73,7 +73,7 @@ class ExecutableFinder
         $suffixes = array('');
         if ('\\' === DIRECTORY_SEPARATOR) {
             $pathExt = getenv('PATHEXT');
-            $suffixes = array_merge($suffixes, $pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes);
+            $suffixes = array_merge($pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes, $suffixes);
         }
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {


### PR DESCRIPTION
Executable finder should consider "executable" suffixes first on Windows because we basically ignore executability on Windows (line 80 below the change), which leads, for example, to finding usually-non-executable `phpunit` file first where both `phpunit` and `phpunit.bat` are present.