### PR TITLE
Prevent warning in proc_open()

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -332,7 +332,7 @@ class Process implements \IteratorAggregate
             throw new RuntimeException(sprintf('The provided cwd "%s" does not exist.', $this->cwd));
         }
 
-        $this->process = proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $options);
+        $this->process = @ proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $options);
 
         if (!\is_resource($this->process)) {
             throw new RuntimeException('Unable to launch a new process.');


### PR DESCRIPTION
In addition to returning `false`, `proc_open()` triggers a warning when it fails. For example:

>  Warning: proc_open(): fork failed - Cannot allocate memory

When using the `ErrorHandler`, the warning gets promoted to an exception, and the next line, `if (! is_resource(...`, is not executed.