### PR TITLE
Changed Process.php to include support for create_new_console (Windows ONLY)

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -333,10 +333,9 @@ class Process implements \IteratorAggregate
             throw new RuntimeException(sprintf('The provided cwd "%s" does not exist.', $this->cwd));
         }
 
-        $this->process = @proc_open($commandline, $descriptors, $pipes, $this->cwd, $envPairs, $this->options );
+        $this->process = @proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options );
 
         if(!$this->options['create_new_console']){
-
             if (!\is_resource($this->process)) {
                 throw new RuntimeException('Unable to launch a new process.');
             }


### PR DESCRIPTION
I created a quick Repo [https://github.com/andrei0x309/tets_sym_proc](https://github.com/andrei0x309/tets_sym_proc) to illustrate
how this feature can be used, it essentially lets you run something even if your main script has terminated. 

It is useful if you want to create something like 
`new Process(['php', 'script_with_long_execution_time.php']);`
This was impossible to do on windows until the **create_new_console** flag was added in PHP 7.4.4.
With this feature Process can be used like this:

```
// Start a process and detach form it on Win only
$process = new Process(['php', 'worker.php']);
$process->setWinOptions(["create_new_console" => true]); // New method I added
$process->disableOutput();
$process->start();
```

Process  Class behavior will never change if the user doesn't use `setWinOptions()`
