### PR TITLE
Add a waiting callback 

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -398,6 +398,7 @@ class Process implements \IteratorAggregate
      * It allows to have feedback from the independent process during execution.
      *
      * @param callable|null $callback A valid PHP callback
+     * @param callable|null $waitingCallback A valid PHP callback triggered while waiting
      *
      * @return int The exitcode of the process
      *
@@ -405,7 +406,7 @@ class Process implements \IteratorAggregate
      * @throws ProcessSignaledException When process stopped after receiving signal
      * @throws LogicException           When process is not yet started
      */
-    public function wait(callable $callback = null): int
+    public function wait(callable $callback = null, callable $waitingCallback): int
     {
         $this->requireProcessIsStarted(__FUNCTION__);
 
@@ -420,6 +421,7 @@ class Process implements \IteratorAggregate
         }
 
         do {
+            $waitingCallback($this);
             $this->checkTimeout();
             $running = '\\' === \DIRECTORY_SEPARATOR ? $this->isRunning() : $this->processPipes->areOpen();
             $this->readPipes($running, '\\' !== \DIRECTORY_SEPARATOR || !$running);


### PR DESCRIPTION
Add the possibility to add a callback while waiting for the process to finish. This allows to add Logging or other actions.

```php
class Example {

    private PsrLogger $logger;

    function runMyProcess() {
        $process->wait(
            null, 
            function (ProcessStatus $ProcessStatus): void {
                    $this->logger->debug(
                        'Running Render Videofile process with PID ' . $meltProcessStatus->getSymfonyProcess()->getPid()
                    );
            }
        );
    }
}
```