### PR TITLE
Add Laravel Herd lookup path

### DIFF
--- a/PhpExecutableFinder.php
+++ b/PhpExecutableFinder.php
@@ -81,6 +81,10 @@ class PhpExecutableFinder
             $dirs[] = 'C:\xampp\php\\';
         }
 
+        if ($herdPath = getenv('HERD_HOME')) {
+            $dirs[] = $herdPath . ('\\' === \DIRECTORY_SEPARATOR ? '\\bin' : '/bin');
+        }
+
         return $this->executableFinder->find('php', false, $dirs);
     }
 


### PR DESCRIPTION
As the PhpExecutableFinder is already aware of XAMPP, it might be a good idea to also add support for Laravel Herd, which is widely used.

Laravel Herd uses statically compiled PHP binaries, which is why the `PHP_BINDIR` folder always points to `/bin` instead of a user-specific folder.
As Laravel Herd adds a `HERD_HOME` environment variable, we can check for the existence of this variable and then add the `bin` subdirectory to the list of directories to search.

I couldn't find any tests for xampp, which is why I haven't included any for this addition.